### PR TITLE
dataset, summary and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+result
+__pycache__
+implementations
+data

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,5 @@
 torch
+torch-summary
 scikit-learn
 torchvision
 pillow

--- a/implementations/general/__init__.py
+++ b/implementations/general/__init__.py
@@ -1,5 +1,5 @@
 
-from .anime_face import AnimeFaceDataset, LabeledAnimeFaceDataset, OneHotLabeledAnimeFaceDataset
+from .anime_face import AnimeFaceDataset, LabeledAnimeFaceDataset, OneHotLabeledAnimeFaceDataset, YearAnimeFaceDataset
 from .danbooru import DanbooruDataset, GeneratePairImageDanbooruDataset
 from .danbooru_portrait import DanbooruPortraitDataset
 

--- a/implementations/general/danbooru_portrait.py
+++ b/implementations/general/danbooru_portrait.py
@@ -18,7 +18,7 @@ class DanbooruPortraitDataset(Dataset):
             self.transform = transform
         else:
             self.transform = T.Compose([
-                T.Resize(int(image_size*1.3)),
+                T.Resize(int(image_size*1.2)),
                 T.CenterCrop(image_size),
                 T.RandomHorizontalFlip(),
                 T.ToTensor(),
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     print(len(dataset))
     dataset = DataLoader(dataset, batch_size=32, shuffle=True)
     print(len(dataset))
-    exit()
+    # exit()
 
     from torchvision.utils import save_image
     for image in dataset:


### PR DESCRIPTION
# WHAT
- change image resize ratio for Danbooru portrait dataset
- make YearAnimeFaceDataset importable
- add `.dockerignore`
- add [torch-summary](https://github.com/tyleryep/torch-summary) to requirements.txt